### PR TITLE
hardcode maxretries value

### DIFF
--- a/modules/local/features.nf
+++ b/modules/local/features.nf
@@ -3,7 +3,7 @@ process GET_UNI2_FEATURES {
     tag "$sample_id"
     label 'process_uni2'
     maxRetries 2
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     memory { 56.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 16.GB }
     publishDir "${params.outdir}/${sample_id}/features", pattern: 'features/*.tsv.gz', saveAs: { filename -> "${params.subtiling}-${expansion_factor}-${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
     

--- a/modules/local/features.nf
+++ b/modules/local/features.nf
@@ -2,7 +2,6 @@ process GET_UNI2_FEATURES {
 
     tag "$sample_id"
     label 'process_uni2'
-    maxRetries 2
     errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     memory { 56.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 16.GB }
     publishDir "${params.outdir}/${sample_id}/features", pattern: 'features/*.tsv.gz', saveAs: { filename -> "${params.subtiling}-${expansion_factor}-${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish

--- a/modules/local/focus.nf
+++ b/modules/local/focus.nf
@@ -4,7 +4,7 @@ process CHECK_FOCUS {
     tag "$sample_id"
     label 'process_focus'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     memory { 12.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 12.GB }
     publishDir "${params.outdir}/${sample_id}/focus", pattern: 'output/*', saveAs: { "${file(it).getFileName()}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
     

--- a/modules/local/focus.nf
+++ b/modules/local/focus.nf
@@ -3,7 +3,6 @@ process CHECK_FOCUS {
 
     tag "$sample_id"
     label 'process_focus'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     memory { 12.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 12.GB }
     publishDir "${params.outdir}/${sample_id}/focus", pattern: 'output/*', saveAs: { "${file(it).getFileName()}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish

--- a/modules/local/hovernet.nf
+++ b/modules/local/hovernet.nf
@@ -71,7 +71,6 @@ process INFER_PREP_HOVERNET {
     tag "$sample_id"
     label 'process_hovernet'
     memory { 30.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 12.GB }
-    maxRetries 0
     errorStrategy  { task.attempt <= 0  ? 'retry' : 'finish' }
     
     input:
@@ -119,7 +118,6 @@ process INFER_HOVERNET {
     tag "$sample_id"
     label 'process_post_hovernet'
     memory { 30.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 12.GB }
-    maxRetries 0
     errorStrategy  { task.attempt <= 0  ? 'retry' : 'finish' }
     
     input:
@@ -167,7 +165,6 @@ process GET_NUCLEI_MASK_FROM_HOVERNET_JSON {
 
     tag "$sample_id"
     label 'python_process_low'
-    maxRetries 2
     errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * task.attempt * 6.GB }
     
@@ -223,7 +220,6 @@ process INFER_HOVERNET_TILES {
 
     tag "$sample_id"
     label 'process_hovernet'
-    maxRetries 1
     errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}/tiles", pattern: 'temp/overlay/*.png', saveAs: { filename -> "${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 16.GB }
@@ -318,7 +314,6 @@ process INFER_STARDIST {
 
     tag "$sample_id"
     label 'process_stardist'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 16.GB }
     
@@ -388,7 +383,6 @@ process COMPRESS_JSON_FILE {
 
     tag "$sample_id"
     label 'vips_process'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     
@@ -410,7 +404,6 @@ process COMPUTE_SEGMENTATION_DATA {
 
     tag "$sample_id"
     label 'python_process_low'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 6.GB * task.attempt + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 6.GB * task.attempt }
@@ -442,7 +435,6 @@ process GENERATE_PERSPOT_SEGMENTATION_DATA {
 
     tag "$sample_id"
     label 'python_process_low'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 4.GB * task.attempt + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 4.GB * task.attempt }

--- a/modules/local/hovernet.nf
+++ b/modules/local/hovernet.nf
@@ -72,7 +72,7 @@ process INFER_PREP_HOVERNET {
     label 'process_hovernet'
     memory { 30.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 12.GB }
     maxRetries 0
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 0  ? 'retry' : 'finish' }
     
     input:
     tuple val(sample_id), path(image), path(mask), val(size)
@@ -120,7 +120,7 @@ process INFER_HOVERNET {
     label 'process_post_hovernet'
     memory { 30.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 12.GB }
     maxRetries 0
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 0  ? 'retry' : 'finish' }
     
     input:
     tuple val(sample_id), path(image), path(mask), val(size), file("cache/pred_map.npy")
@@ -168,7 +168,7 @@ process GET_NUCLEI_MASK_FROM_HOVERNET_JSON {
     tag "$sample_id"
     label 'python_process_low'
     maxRetries 2
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * task.attempt * 6.GB }
     
     input:
@@ -224,7 +224,7 @@ process INFER_HOVERNET_TILES {
     tag "$sample_id"
     label 'process_hovernet'
     maxRetries 1
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}/tiles", pattern: 'temp/overlay/*.png', saveAs: { filename -> "${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 16.GB }
     
@@ -319,7 +319,7 @@ process INFER_STARDIST {
     tag "$sample_id"
     label 'process_stardist'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 16.GB }
     
     input:
@@ -389,7 +389,7 @@ process COMPRESS_JSON_FILE {
     tag "$sample_id"
     label 'vips_process'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     
     input:
@@ -411,7 +411,7 @@ process COMPUTE_SEGMENTATION_DATA {
     tag "$sample_id"
     label 'python_process_low'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 6.GB * task.attempt + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 6.GB * task.attempt }
     
@@ -443,7 +443,7 @@ process GENERATE_PERSPOT_SEGMENTATION_DATA {
     tag "$sample_id"
     label 'python_process_low'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 4.GB * task.attempt + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 4.GB * task.attempt }
     

--- a/modules/local/merge.nf
+++ b/modules/local/merge.nf
@@ -3,7 +3,6 @@ process CONVERT_SEGMENTATION_DATA {
 
     tag "$sample_id"
     label 'python_low_process'
-    maxRetries 1
     errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 1.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 3.GB }

--- a/modules/local/merge.nf
+++ b/modules/local/merge.nf
@@ -4,7 +4,7 @@ process CONVERT_SEGMENTATION_DATA {
     tag "$sample_id"
     label 'python_low_process'
     maxRetries 1
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 1.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 3.GB }
     

--- a/modules/local/ome.nf
+++ b/modules/local/ome.nf
@@ -4,7 +4,7 @@ process CONVERT_TO_PYRAMIDAL_OME {
     tag "$sample_id"
     label 'process_ome'
     maxRetries 1
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", pattern: 'image.ome.tiff', mode: 'copy', overwrite: params.overwrite_files_on_publish
     
     input:
@@ -37,7 +37,7 @@ process EXTRACT_IMAGE_METADATA {
     tag "$sample_id"
     label 'process_ome'
     maxRetries 1
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", pattern: 'metadata.ome.xml', mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 4.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 0.GB }
 

--- a/modules/local/ome.nf
+++ b/modules/local/ome.nf
@@ -3,7 +3,6 @@ process CONVERT_TO_PYRAMIDAL_OME {
 
     tag "$sample_id"
     label 'process_ome'
-    maxRetries 1
     errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", pattern: 'image.ome.tiff', mode: 'copy', overwrite: params.overwrite_files_on_publish
     
@@ -36,7 +35,6 @@ process EXTRACT_IMAGE_METADATA {
 
     tag "$sample_id"
     label 'process_ome'
-    maxRetries 1
     errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", pattern: 'metadata.ome.xml', mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 4.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 0.GB }

--- a/modules/local/postprocessing.nf
+++ b/modules/local/postprocessing.nf
@@ -4,7 +4,7 @@ process DIMRED_CLUSTER_MORPH {
     tag "$sample_id"
     label 'python_low_process'
     maxRetries 2
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}/figures", pattern: 'figures/*/*.png', saveAs: { filename -> "${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 1.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 3.GB }
     
@@ -117,7 +117,7 @@ process DIMRED_CLUSTER {
     tag "$sample_id"
     label 'python_low_process'
     maxRetries 2
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}/figures", pattern: 'figures/*/*.png', saveAs: { filename -> "${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 1.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 3.GB }
     

--- a/modules/local/postprocessing.nf
+++ b/modules/local/postprocessing.nf
@@ -3,7 +3,6 @@ process DIMRED_CLUSTER_MORPH {
 
     tag "$sample_id"
     label 'python_low_process'
-    maxRetries 2
     errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}/figures", pattern: 'figures/*/*.png', saveAs: { filename -> "${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 1.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 3.GB }
@@ -116,7 +115,6 @@ process DIMRED_CLUSTER {
 
     tag "$sample_id"
     label 'python_low_process'
-    maxRetries 2
     errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}/figures", pattern: 'figures/*/*.png', saveAs: { filename -> "${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 1.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 3.GB }

--- a/modules/local/superpixel.nf
+++ b/modules/local/superpixel.nf
@@ -4,7 +4,7 @@ process SUPERPIXELATION {
     tag "$sample_id"
     label 'process_inception'
     maxRetries 1
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 12.GB }
     publishDir "${params.outdir}/${sample_id}/superpixels", pattern: "superpixelation_*.png", mode: 'copy', overwrite: params.overwrite_files_on_publish
     cpus 1
@@ -34,7 +34,7 @@ process EXPORT_DOWN_IMAGE_FOR_CONTOURS {
     tag "$sample_id"
     label 'process_inception'
     maxRetries 1
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 5.GB }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     cpus 1
@@ -67,7 +67,7 @@ process EXPORT_SUPERPIXELATION_CONTOURS {
     tag "$sample_id"
     label 'process_inception'
     maxRetries 1
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 3.GB }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     cpus 1
@@ -105,7 +105,7 @@ process CALCULATE_CELLS_OD {
     tag "$sample_id"
     label 'process_inception'
     maxRetries 0
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 0  ? 'retry' : 'finish' }
     memory { 3.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 11.GB }
     cpus 1
     
@@ -180,7 +180,7 @@ process ASSIGN_NUCLEI_TO_SUPERPIXELS {
     tag "$sample_id"
     label 'process_inception'
     maxRetries 1
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 3.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 3.GB }
     cpus 1

--- a/modules/local/superpixel.nf
+++ b/modules/local/superpixel.nf
@@ -3,7 +3,6 @@ process SUPERPIXELATION {
 
     tag "$sample_id"
     label 'process_inception'
-    maxRetries 1
     errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 12.GB }
     publishDir "${params.outdir}/${sample_id}/superpixels", pattern: "superpixelation_*.png", mode: 'copy', overwrite: params.overwrite_files_on_publish
@@ -33,7 +32,6 @@ process EXPORT_DOWN_IMAGE_FOR_CONTOURS {
 
     tag "$sample_id"
     label 'process_inception'
-    maxRetries 1
     errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 5.GB }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
@@ -66,7 +64,6 @@ process EXPORT_SUPERPIXELATION_CONTOURS {
 
     tag "$sample_id"
     label 'process_inception'
-    maxRetries 1
     errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 3.GB }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
@@ -104,7 +101,6 @@ process CALCULATE_CELLS_OD {
 
     tag "$sample_id"
     label 'process_inception'
-    maxRetries 0
     errorStrategy  { task.attempt <= 0  ? 'retry' : 'finish' }
     memory { 3.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 11.GB }
     cpus 1
@@ -179,7 +175,6 @@ process ASSIGN_NUCLEI_TO_SUPERPIXELS {
 
     tag "$sample_id"
     label 'process_inception'
-    maxRetries 1
     errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 3.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 3.GB }

--- a/modules/local/tasks.nf
+++ b/modules/local/tasks.nf
@@ -55,7 +55,6 @@ process GET_IMAGE_SIZE {
 
     tag "$sample_id"
     label 'process_estimate_size'
-    maxRetries 1
     errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
 
     input:
@@ -76,7 +75,6 @@ process EXTRACT_ROI {
 
     tag "$sample_id"
     label 'process_extract'
-    maxRetries 1
     errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 18.GB }
 
@@ -98,7 +96,6 @@ process COLOR_NORMALIZATION {
 
     tag "$sample_id"
     label 'color_normalization_process'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 30.GB }
 
@@ -124,7 +121,6 @@ process STAIN_NORMALIZATION {
 
     tag "$sample_id"
     label 'stain_normalization_process'
-    maxRetries 1
     errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 12.GB }
 
@@ -151,7 +147,6 @@ process RESIZE_IMAGE {
 
     tag "$sample_id"
     label 'vips_process'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     
     input:
@@ -179,7 +174,6 @@ process CONVERT_TO_TILED_TIFF {
 
     tag "$sample_id"
     label 'vips_process'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", pattern: 'thumbnail.tiff', mode: 'copy', overwrite: params.overwrite_files_on_publish
     
@@ -204,7 +198,6 @@ process GET_THUMB {
 
     tag "$sample_id"
     label 'process_extract'
-    maxRetries 0
     errorStrategy  { task.attempt <= 0  ? 'retry' : 'finish' }
     memory { 64.GB }
     publishDir "${params.outdir}/${sample_id}", pattern: 'thumbnail.tiff', mode: 'copy', overwrite: params.overwrite_files_on_publish
@@ -259,7 +252,6 @@ process MAKE_TINY_THUMB {
 
     tag "$sample_id"
     label 'process_extract'
-    maxRetries 0
     errorStrategy  { task.attempt <= 0  ? 'retry' : 'finish' }
     memory { 2.GB }
     publishDir "${params.outdir}/${sample_id}", pattern: 'thumbnail.jpeg', mode: 'copy', overwrite: params.overwrite_files_on_publish
@@ -285,7 +277,6 @@ process GET_PIXEL_MASK {
 
     tag "$sample_id"
     label 'python_process_low'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 3.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 3.GB }
@@ -316,7 +307,6 @@ process GET_TISSUE_MASK {
 
     tag "$sample_id"
     label 'python_process_low'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 3.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 6.GB * task.attempt }
@@ -351,7 +341,6 @@ process TILE_WSI {
 
     tag "$sample_id"
     label 'python_process_low'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 3.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 6.GB * task.attempt }
@@ -431,7 +420,6 @@ process GET_TILE_MASK {
 
     tag "$sample_id"
     label 'python_process_low'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 3.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 6.GB * task.attempt }
@@ -464,7 +452,6 @@ process GET_INCEPTION_FEATURES {
 
     tag "$sample_id"
     label 'process_inception'
-    maxRetries 2
     errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     memory { 36.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 14.GB }
     //publishDir "${params.outdir}/${sample_id}", pattern: 'features/*.tsv.gz', mode: 'copy', overwrite: true
@@ -505,7 +492,6 @@ process GET_CTRANSPATH_FEATURES {
 
     tag "$sample_id"
     label 'process_ctranspath'
-    maxRetries 2
     errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     memory { 56.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 16.GB }
     //publishDir "${params.outdir}/${sample_id}", pattern: 'features/*.tsv.gz', mode: 'copy', overwrite: true
@@ -551,7 +537,6 @@ process GET_MOCOV3_FEATURES {
 
     tag "$sample_id"
     label 'process_mocov3'
-    maxRetries 0
     errorStrategy  { task.attempt <= 0  ? 'retry' : 'finish' }
     memory { 56.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 16.GB }
     publishDir "${params.outdir}/${sample_id}/features", pattern: 'features/*.tsv.gz', saveAs: { filename -> "${params.subtiling}-${expansion_factor}-${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
@@ -598,7 +583,6 @@ process GET_UNI_FEATURES {
 
     tag "$sample_id"
     label 'process_uni'
-    maxRetries 2
     errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     memory { 56.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 16.GB }
     publishDir "${params.outdir}/${sample_id}/features", pattern: 'features/*.tsv.gz', saveAs: { filename -> "${params.subtiling}-${expansion_factor}-${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
@@ -642,7 +626,6 @@ process GET_CONCH_FEATURES {
 
     tag "$sample_id"
     label 'process_conch'
-    maxRetries 2
     errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     memory { 60.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 16.GB }
     publishDir "${params.outdir}/${sample_id}/features", pattern: 'features/*.tsv.gz', saveAs: { filename -> "${params.subtiling}-${expansion_factor}-${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
@@ -687,7 +670,6 @@ process SELECT_SAVE_TILES {
 
     tag "$sample_id"
     label 'python_process_low'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", pattern: 'tiles/*.csv', mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 2.GB }
@@ -737,7 +719,6 @@ process GET_INCEPTION_FEATURES_TILES {
 
     tag "$sample_id"
     label 'process_inception'
-    maxRetries 3
     errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", pattern: 'tiles/*.csv.gz', mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 4.GB }

--- a/modules/local/tasks.nf
+++ b/modules/local/tasks.nf
@@ -56,7 +56,7 @@ process GET_IMAGE_SIZE {
     tag "$sample_id"
     label 'process_estimate_size'
     maxRetries 1
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
 
     input:
     tuple val(sample_id), path(fileslide), path(roifile), val(mpp)
@@ -77,7 +77,7 @@ process EXTRACT_ROI {
     tag "$sample_id"
     label 'process_extract'
     maxRetries 1
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 18.GB }
 
     input:
@@ -99,7 +99,7 @@ process COLOR_NORMALIZATION {
     tag "$sample_id"
     label 'color_normalization_process'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 30.GB }
 
     input:
@@ -125,7 +125,7 @@ process STAIN_NORMALIZATION {
     tag "$sample_id"
     label 'stain_normalization_process'
     maxRetries 1
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 1  ? 'retry' : 'finish' }
     memory { 6.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 12.GB }
 
     input:
@@ -152,7 +152,7 @@ process RESIZE_IMAGE {
     tag "$sample_id"
     label 'vips_process'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     
     input:
     tuple val(sample_id), path(image), val(mpp)
@@ -180,7 +180,7 @@ process CONVERT_TO_TILED_TIFF {
     tag "$sample_id"
     label 'vips_process'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", pattern: 'thumbnail.tiff', mode: 'copy', overwrite: params.overwrite_files_on_publish
     
     input:
@@ -205,7 +205,7 @@ process GET_THUMB {
     tag "$sample_id"
     label 'process_extract'
     maxRetries 0
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 0  ? 'retry' : 'finish' }
     memory { 64.GB }
     publishDir "${params.outdir}/${sample_id}", pattern: 'thumbnail.tiff', mode: 'copy', overwrite: params.overwrite_files_on_publish
     
@@ -260,7 +260,7 @@ process MAKE_TINY_THUMB {
     tag "$sample_id"
     label 'process_extract'
     maxRetries 0
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 0  ? 'retry' : 'finish' }
     memory { 2.GB }
     publishDir "${params.outdir}/${sample_id}", pattern: 'thumbnail.jpeg', mode: 'copy', overwrite: params.overwrite_files_on_publish
     
@@ -286,7 +286,7 @@ process GET_PIXEL_MASK {
     tag "$sample_id"
     label 'python_process_low'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 3.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 3.GB }
     
@@ -317,7 +317,7 @@ process GET_TISSUE_MASK {
     tag "$sample_id"
     label 'python_process_low'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 3.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 6.GB * task.attempt }
     
@@ -352,7 +352,7 @@ process TILE_WSI {
     tag "$sample_id"
     label 'python_process_low'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 3.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 6.GB * task.attempt }
     
@@ -432,7 +432,7 @@ process GET_TILE_MASK {
     tag "$sample_id"
     label 'python_process_low'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 3.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 6.GB * task.attempt }
     
@@ -465,7 +465,7 @@ process GET_INCEPTION_FEATURES {
     tag "$sample_id"
     label 'process_inception'
     maxRetries 2
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     memory { 36.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 14.GB }
     //publishDir "${params.outdir}/${sample_id}", pattern: 'features/*.tsv.gz', mode: 'copy', overwrite: true
     publishDir "${params.outdir}/${sample_id}/features", pattern: 'features/*.tsv.gz', saveAs: { filename -> "${params.subtiling}-${expansion_factor}-${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
@@ -506,7 +506,7 @@ process GET_CTRANSPATH_FEATURES {
     tag "$sample_id"
     label 'process_ctranspath'
     maxRetries 2
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     memory { 56.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 16.GB }
     //publishDir "${params.outdir}/${sample_id}", pattern: 'features/*.tsv.gz', mode: 'copy', overwrite: true
     publishDir "${params.outdir}/${sample_id}/features", pattern: 'features/*.tsv.gz', saveAs: { filename -> "${params.subtiling}-${expansion_factor}-${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
@@ -552,7 +552,7 @@ process GET_MOCOV3_FEATURES {
     tag "$sample_id"
     label 'process_mocov3'
     maxRetries 0
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 0  ? 'retry' : 'finish' }
     memory { 56.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 16.GB }
     publishDir "${params.outdir}/${sample_id}/features", pattern: 'features/*.tsv.gz', saveAs: { filename -> "${params.subtiling}-${expansion_factor}-${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
     
@@ -599,7 +599,7 @@ process GET_UNI_FEATURES {
     tag "$sample_id"
     label 'process_uni'
     maxRetries 2
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     memory { 56.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 16.GB }
     publishDir "${params.outdir}/${sample_id}/features", pattern: 'features/*.tsv.gz', saveAs: { filename -> "${params.subtiling}-${expansion_factor}-${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
     
@@ -643,7 +643,7 @@ process GET_CONCH_FEATURES {
     tag "$sample_id"
     label 'process_conch'
     maxRetries 2
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
     memory { 60.GB + (Float.valueOf(size) / 1000.0).round(2) * params.memory_scale_factor * 16.GB }
     publishDir "${params.outdir}/${sample_id}/features", pattern: 'features/*.tsv.gz', saveAs: { filename -> "${params.subtiling}-${expansion_factor}-${filename.split("/")[filename.split("/").length - 1]}" }, mode: 'copy', overwrite: params.overwrite_files_on_publish
     
@@ -688,7 +688,7 @@ process SELECT_SAVE_TILES {
     tag "$sample_id"
     label 'python_process_low'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", pattern: 'tiles/*.csv', mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 2.GB }
     
@@ -738,7 +738,7 @@ process GET_INCEPTION_FEATURES_TILES {
     tag "$sample_id"
     label 'process_inception'
     maxRetries 3
-    errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+    errorStrategy  { task.attempt <= 3  ? 'retry' : 'finish' }
     publishDir "${params.outdir}/${sample_id}", pattern: 'tiles/*.csv.gz', mode: 'copy', overwrite: params.overwrite_files_on_publish
     memory { 4.GB }
     


### PR DESCRIPTION
closes #6 

Newer Nextflow versions don't allow referencing the `maxRetries` variable within `errorStrategy` closures. This causes process directives to fail at runtime.

## Changes

Removed all `maxRetries` directive declarations and replaced variable references in `errorStrategy` with hardcoded values:

```diff
process EXAMPLE {
-   maxRetries 2
-   errorStrategy  { task.attempt <= maxRetries  ? 'retry' : 'finish' }
+   errorStrategy  { task.attempt <= 2  ? 'retry' : 'finish' }
}
```